### PR TITLE
feat: cpu_count improved

### DIFF
--- a/meta/lib/oe/utils.py
+++ b/meta/lib/oe/utils.py
@@ -163,7 +163,7 @@ def trim_version(version, num_parts=2):
 
 def cpu_count():
     import multiprocessing
-    return multiprocessing.cpu_count()
+    return int(multiprocessing.cpu_count()*1.5)
 
 def execute_pre_post_process(d, cmds):
     if cmds is None:


### PR DESCRIPTION
this function allows to automatically determine the number of maximum jobs in Yocto. Normally the cpu_count is the maximum value but after numerous tests, multiplying it by 1.5 is still alright since most tasks are light, cpus can handle them properly